### PR TITLE
Fix Docs Search

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -110,10 +110,7 @@ on_rtd = os.environ.get("READTHEDOCS") == "True"
 if on_rtd:
     html_theme = "default"
 else:
-    import sphinx_rtd_theme
-
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Search was failing in docbot because of a sphinx_rtd_theme configuration problem.